### PR TITLE
**Updated:** .vsix Manifest file to allow Extension to be compatible with VS 2019

### DIFF
--- a/VSBuildOptimizer/source.extension.vsixmanifest
+++ b/VSBuildOptimizer/source.extension.vsixmanifest
@@ -20,7 +20,7 @@ Project also can show independent projects in your solution and check all lib re
     <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to work with Visual Studio 2019.

Original issue: [Issue #3 - Not working on VS 2019](https://github.com/alexSatov/VSBuildOptimizer/issues/3)

This involved a minor update to the Manifest file which updates the Version Range for the '**Microsoft.VisualStudio.Component.CoreEditor**' prerequisite.

Hope this helps!